### PR TITLE
Use path.normalize to fix search on Windows

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -115,7 +115,8 @@ function articlesContainSpecificArticle(articles, articlePath) {
     Array.isArray(articles) &&
     articles.some(
       // compare articles by absolute file path
-      (article) => path.resolve("data", article.file) === articlePath
+      // use path.normalize for windows paths
+      (article) => path.normalize(path.resolve("data", article.file)) === path.normalize(articlePath)
     )
   )
 }


### PR DESCRIPTION
I found and fixed a bug when developing on windows. Since the paths on Windows use a different slash it wasn't matching the article paths correctly. 

E.g.
`C:\dev\docs\gatsby-starter-help-center\content\deploy\index.md`
`C:/dev/docs/gatsby-starter-help-center/content/welcome/index.md`

`path.normalize` will normalize the paths and fix this issue.